### PR TITLE
[FIX] (NavigationPopRoute): fixed OOR error when source is a child VC…

### DIFF
--- a/JustRoute/JustRoute/ViewController/Navigation/JRNavigationPopRoute.m
+++ b/JustRoute/JustRoute/ViewController/Navigation/JRNavigationPopRoute.m
@@ -72,10 +72,20 @@
     if (self.destination == nil)
     {
         NSArray <UIViewController *> *viewControllers = navigationController.viewControllers;
-        NSUInteger indexOfSource = [viewControllers indexOfObject:source];
-        if (indexOfSource > 0)
+        NSUInteger indexOfDestination = [viewControllers indexOfObject:source] - 1;
+
+        if (![viewControllers containsObject:source]){
+            [viewControllers enumerateObjectsUsingBlock:^(UIViewController * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+                if ([obj.childViewControllers containsObject:source]) {
+                    indexOfDestination = idx;
+                    *stop = YES;
+                }
+            }];
+        }
+
+        if (indexOfDestination >= 0)
         {
-            self.destination = [viewControllers objectAtIndex:indexOfSource - 1];
+            self.destination = [viewControllers objectAtIndex:indexOfDestination];
         }
     }
     [self prepareForRoute];


### PR DESCRIPTION
If there is a child VC on stack, then we have to check its parent index